### PR TITLE
chore(npm): Update publish-npm action to stop using tokens

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @stenciljs/technical-steering-committee

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @stenciljs/technical-steering-committee

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,12 @@ jobs:
     name: Build Stencil Sass
     runs-on: 'ubuntu-latest'
     steps:
-      - name: 🧑‍💻 Checkout Code
+      - name: 📥 Checkout Code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
-      - name: 📦 Get Core Dependencies
+      - name: 🕸️ Get Core Dependencies
         uses: stenciljs/.github/actions/get-core-dependencies@main
 
       - name: 🏗️ Build

--- a/actions/download-archive/action.yml
+++ b/actions/download-archive/action.yml
@@ -7,7 +7,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Get Project Name
+    - name: 🔍 Get Project Name
       id: repo-name
       run: |
         REPO_NAME=${GITHUB_REPOSITORY#*/}
@@ -20,11 +20,11 @@ runs:
         name: ${{ steps.repo-name.outputs.REPO_NAME }}
         path: ${{ inputs.path }}
 
-    - name: Extract Archive
+    - name: 🔃 Extract Archive
       run: unzip -q -o ${{ inputs.path }}/${{ steps.repo-name.outputs.REPO_NAME }}.zip
       shell: bash
 
     # Remove the ZIP file after we've extracted it - we don't want this committed back to the repo
-    - name: Delete The Archive ZIP File
+    - name: 🗑️ Delete The Archive ZIP File
       run: rm ${{ inputs.path }}/${{ steps.repo-name.outputs.REPO_NAME }}.zip
       shell: bash

--- a/actions/get-core-dependencies/action.yml
+++ b/actions/get-core-dependencies/action.yml
@@ -6,12 +6,12 @@ runs:
     # this overrides previous versions of the node runtime that was set.
     # jobs that need a different version of the Node runtime should explicitly
     # set their node version after running this step
-    - name: Use Node Version from .nvmrc
-      uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+    - name: 🟢 Use Node Version from .nvmrc
+      uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
       with:
         node-version-file: '.nvmrc'
         cache: 'npm'
 
-    - name: Install Dependencies
+    - name: 📦 Install Dependencies
       run: npm ci
       shell: bash

--- a/actions/publish-npm/action.yml
+++ b/actions/publish-npm/action.yml
@@ -5,8 +5,6 @@ inputs:
     description: The type of version to release.
   tag:
     description: The tag to publish to on NPM.
-  token:
-    description: The NPM authentication token required to publish.
   github-token:
     description: The GitHub token required to push to the repository.
     required: false
@@ -18,6 +16,14 @@ inputs:
     description: Skip the setup steps.
     required: false
     default: "no"
+  node-version:
+    description: Node.js version to use when preparing the publish environment.
+    required: false
+    default: '20'
+  registry-url:
+    description: Registry URL used for npm publish.
+    required: false
+    default: 'https://registry.npmjs.org'
 
 runs:
   using: 'composite'
@@ -46,6 +52,13 @@ runs:
     - name: 📥 Download Build Archive
       if: inputs.skip-setup == 'no'
       uses: stenciljs/.github/actions/download-archive@main
+
+    - name: 🟢 Configure Node for Publish
+      if: inputs.skip-setup == 'no'
+      uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+      with:
+        node-version: ${{ inputs.node-version }}
+        registry-url: ${{ inputs.registry-url }}
 
     - name: 🔧 Configure Git
       if: inputs.tag == 'latest'
@@ -162,12 +175,11 @@ runs:
       run: git status
       shell: bash
 
-    - name: 🔧 Prepare NPM Token
-      run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
+    - name: 🔄 Ensure Latest npm
+      if: inputs.skip-setup == 'no'
+      run: npm install -g npm@latest
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      env:
-        NPM_TOKEN: ${{ inputs.token }}
 
     - name: 📦 Publish to NPM
       run: npm publish --tag ${{ inputs.tag }} --provenance

--- a/actions/publish-npm/action.yml
+++ b/actions/publish-npm/action.yml
@@ -23,18 +23,18 @@ runs:
   using: 'composite'
   steps:
     # Log the input from GitHub Actions for easy traceability
-    - name: Log Inputs
+    - name: 📝 Log Inputs
       run: |
         echo "Version: ${{ inputs.version }}"
         echo "Tag: ${{ inputs.tag }}"
       working-directory: ${{ inputs.working-directory }}
       shell: bash
 
-    - name: Get Core Dependencies
+    - name: 🕸️ Get Core Dependencies
       if: inputs.skip-setup == 'no'
       uses: stenciljs/.github/actions/get-core-dependencies@main
 
-    - name: Get Project Name
+    - name: 🔍 Get Project Name
       id: repo-name
       run: |
         REPO_NAME=${GITHUB_REPOSITORY#*/}
@@ -43,11 +43,11 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       shell: bash
 
-    - name: Download Build Archive
+    - name: 📥 Download Build Archive
       if: inputs.skip-setup == 'no'
       uses: stenciljs/.github/actions/download-archive@main
 
-    - name: Configure Git
+    - name: 🔧 Configure Git
       if: inputs.tag == 'latest'
       run: |
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
@@ -55,19 +55,19 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       shell: bash
 
-    - name: Bump Version
+    - name: 🏷️ Bump Version
       if: inputs.tag == 'dev'
       run: npm version --no-git-tag-version ${{ inputs.version }} --tag-version-prefix="v" --message "v%s"
       working-directory: ${{ inputs.working-directory }}
       shell: bash
 
-    - name: Bump Version
+    - name: 🏷️ Bump Version
       if: inputs.tag == 'latest'
       run: npm version ${{ inputs.version }} --tag-version-prefix="v" --message "v%s"
       working-directory: ${{ inputs.working-directory }}
       shell: bash
     
-    - name: Get Tag Name
+    - name: 🔍 Get Tag Name
       id: package-version
       if: inputs.tag == 'latest'
       run: |
@@ -77,7 +77,7 @@ runs:
       shell: bash
 
     # Note: we don't commit the changelog file as we show it as part of the GitHub Release
-    - name: Create Changelog
+    - name: 📝 Create Changelog
       if: inputs.tag == 'latest'
       run: |
         # Download the git-conventional-commits config file
@@ -119,7 +119,7 @@ runs:
         rm ./git-conventional-commits.yml.bak
       shell: bash
 
-    - name: Push Version
+    - name: 🔄 Push Version
       if: inputs.tag == 'latest'
       run: |
         echo "Make version commit"
@@ -136,11 +136,11 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
 
-    - name: Display Changelog
+    - name: 📝 Display Changelog
       run: cat CHANGELOG.md
       shell: bash
 
-    - name: Push Release
+    - name: 🔄 Push Release
       if: inputs.tag == 'latest'
       uses: softprops/action-gh-release@v2
       env:
@@ -152,24 +152,24 @@ runs:
         tag_name: ${{ steps.package-version.outputs.PKG_JSON_VERSION }}
 
     # Log the git diff for easy debugging
-    - name: Log Generated Changes
+    - name: 📝 Log Generated Changes
       if: inputs.tag == 'dev'
       run: git --no-pager diff
       shell: bash
 
     # Log the git status for easy debugging
-    - name: Log Status
+    - name: 📝 Log Status
       run: git status
       shell: bash
 
-    - name: Prepare NPM Token
+    - name: 🔧 Prepare NPM Token
       run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:
         NPM_TOKEN: ${{ inputs.token }}
 
-    - name: Publish to NPM
+    - name: 📦 Publish to NPM
       run: npm publish --tag ${{ inputs.tag }} --provenance
       working-directory: ${{ inputs.working-directory }}
       shell: bash

--- a/actions/upload-archive/action.yml
+++ b/actions/upload-archive/action.yml
@@ -7,7 +7,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Get Project Name
+    - name: 🔍 Get Project Name
       id: repo-name
       run: |
         REPO_NAME=${GITHUB_REPOSITORY#*/}
@@ -15,7 +15,7 @@ runs:
         echo "Repository name: $REPO_NAME"        
       shell: bash
 
-    - name: Create Archive
+    - name: 🗄️ Create Archive
       run: zip -q -r ${{ steps.repo-name.outputs.REPO_NAME }}.zip ${{ inputs.paths }}
       shell: bash
 


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Workflow configuration update


## What is the current behavior?

- Composite action expected a long-lived npm token and wrote it into `.npmrc`, preventing trusted publishing.

GitHub Issue Number: N/A


## What is the new behavior?

- Configured Node via `actions/setup-node` with the registry URL so GitHub issues an OIDC credential.
- Dropped the token input and the `.npmrc` write, allowing npm to authenticate through trusted publishing requirements [docs.npmjs.com/trusted-publishers](https://docs.npmjs.com/trusted-publishers).
- Leaved optional GitHub release automation intact via the existing `github-token` input.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Testing

- Not run (workflow-only change).

## Other information

- N/A
